### PR TITLE
Folders typos

### DIFF
--- a/src/assetbundles/RestrictAssetDelete/RestrictAssetDeleteAsset.php
+++ b/src/assetbundles/RestrictAssetDelete/RestrictAssetDeleteAsset.php
@@ -43,7 +43,7 @@ class RestrictAssetDeleteAsset extends AssetBundle
     public function init()
     {
         // define the path that your publishable resources live
-        $this->sourcePath = "@lhs/restrictassetdelete/assetbundles/restrictassetdelete/dist";
+        $this->sourcePath = "@lhs/restrictassetdelete/assetbundles/RestrictAssetDelete/dist";
 
         // define the dependencies
         $this->depends = [

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -15,7 +15,7 @@
 
 {% import "_includes/forms" as forms %}
 
-{% do view.registerAssetBundle("lhs\\restrictassetdelete\\assetbundles\\restrictassetdelete\\RestrictAssetDeleteAsset") %}
+{% do view.registerAssetBundle("lhs\\restrictassetdelete\\assetbundles\\RestrictAssetDelete\\RestrictAssetDeleteAsset") %}
 
 {{ forms.lightswitchField({
     label: 'Admin users skip restrictions'|t('restrict-asset-delete'),


### PR DESCRIPTION
Hi,

This fixes an error thrown on the plugin settings page. 
I'm using a Linux environment with composer 2 and the RestrictAssetDeleteAsset.php could not be found due to camelcase issues in file paths.