### PR TITLE
Fixed can skip restriction always returns true for admins

### DIFF
--- a/src/RestrictAssetDelete.php
+++ b/src/RestrictAssetDelete.php
@@ -136,10 +136,6 @@ class RestrictAssetDelete extends Plugin
     protected function canSkipRestriction()
     {
         $user = Craft::$app->user;
-        return (
-                $user->getIsAdmin()
-                && $this->getSettings()->adminCanSkipRestriction
-            )
-            || $user->checkPermission('restrict-asset-delete:skip-restriction');
+        return $user->getIsAdmin() ? $this->getSettings()->adminCanSkipRestriction : $user->checkPermission('restrict-asset-delete:skip-restriction');
     }
 }


### PR DESCRIPTION
PR related to #6 
Tested it on Craft 3.7 for an admin and a permissions driven user